### PR TITLE
Line Clamps Component

### DIFF
--- a/src/components/clamps/LineClamps.jsx
+++ b/src/components/clamps/LineClamps.jsx
@@ -7,7 +7,7 @@ import LineClamp4 from "@/public/images/lineclamps/LineClamp4.webp";
 
 const LineClamps = () => {
   return (
-    <div className="flex flex-col gap-10">
+    <div className="flex items-center flex-col gap-10">
       <Description
         text={
           "J&M Products Line Support Clamps and Brackets are selected by major aerospace, transportation and industrial equipment manufacturers for use in widely varying applications including exposure to hydraulic, fuel, pneumatic and electrical systems."
@@ -21,14 +21,12 @@ const LineClamps = () => {
         img={LineClamp2}
         float={"right"}
       />
-
       <Description
         text={
           "Reliable, proven, off-the-shelf standard MS, NAS, AN and J&M Part numbers, J&M clamps provide fast economical methods of installing wire harnesses, hydraulic lines, or a variety of other applications. J&M line clamps are utilized by virtually every aircraft manufacturer and defense contractor. Heavy duty trucking, Space and Marine applications are also part of our product line."
         }
         img={LineClamp3}
       />
-
       <Description
         text={
           "J&M can customize any required mounting brackets where vibration or loads would exceed clamp, component design limits, or if compound angles are required. Brackets can include the installation of secondary fastening devices as required."
@@ -36,6 +34,7 @@ const LineClamps = () => {
         img={LineClamp4}
         float={"right"}
       />
+      View Our Clamp Catalog
     </div>
   );
 };

--- a/src/components/clamps/LineClamps.jsx
+++ b/src/components/clamps/LineClamps.jsx
@@ -4,10 +4,11 @@ import LineClamp1 from "@/public/images/lineclamps/LineClamp1.webp";
 import LineClamp2 from "@/public/images/lineclamps/LineClamp2.webp";
 import LineClamp3 from "@/public/images/lineclamps/LineClamp3.webp";
 import LineClamp4 from "@/public/images/lineclamps/LineClamp4.webp";
+import { IoDocumentTextOutline } from "react-icons/io5";
 
 const LineClamps = () => {
   return (
-    <div className="flex items-center flex-col gap-10">
+    <div className="flex items-center flex-col gap-10 px-3">
       <Description
         text={
           "J&M Products Line Support Clamps and Brackets are selected by major aerospace, transportation and industrial equipment manufacturers for use in widely varying applications including exposure to hydraulic, fuel, pneumatic and electrical systems."
@@ -34,7 +35,15 @@ const LineClamps = () => {
         img={LineClamp4}
         float={"right"}
       />
-      View Our Clamp Catalog
+      <div className="text-jm-blue-200 underline flex flex-row gap-3">
+        <a
+          href="http://www.jmproducts.com/JMPdocs/JMPcatalogue2001.pdf"
+          target="_blank"
+        >
+          View Our Clamp Catalog
+        </a>
+        <IoDocumentTextOutline />
+      </div>
     </div>
   );
 };

--- a/src/components/clamps/LineClamps.jsx
+++ b/src/components/clamps/LineClamps.jsx
@@ -5,6 +5,7 @@ import LineClamp2 from "@/public/images/lineclamps/LineClamp2.webp";
 import LineClamp3 from "@/public/images/lineclamps/LineClamp3.webp";
 import LineClamp4 from "@/public/images/lineclamps/LineClamp4.webp";
 import { IoDocumentTextOutline } from "react-icons/io5";
+import Link from "next/link";
 
 const LineClamps = () => {
   return (
@@ -36,12 +37,9 @@ const LineClamps = () => {
         float={"right"}
       />
       <div className="text-jm-blue-200 underline flex flex-row gap-3">
-        <a
-          href="http://www.jmproducts.com/JMPdocs/JMPcatalogue2001.pdf"
-          target="_blank"
-        >
+        <Link href="http://www.jmproducts.com/JMPdocs/JMPcatalogue2001.pdf">
           View Our Clamp Catalog
-        </a>
+        </Link>
         <IoDocumentTextOutline />
       </div>
     </div>

--- a/src/components/clamps/LineClamps.jsx
+++ b/src/components/clamps/LineClamps.jsx
@@ -1,7 +1,43 @@
 import React from "react";
+import Description from "../Description";
+import LineClamp1 from "@/public/images/lineclamps/LineClamp1.webp";
+import LineClamp2 from "@/public/images/lineclamps/LineClamp2.webp";
+import LineClamp3 from "@/public/images/lineclamps/LineClamp3.webp";
+import LineClamp4 from "@/public/images/lineclamps/LineClamp4.webp";
 
 const LineClamps = () => {
-  return <div>LineClamps</div>;
+  return (
+    <div className="flex flex-col gap-10">
+      <Description
+        text={
+          "J&M Products Line Support Clamps and Brackets are selected by major aerospace, transportation and industrial equipment manufacturers for use in widely varying applications including exposure to hydraulic, fuel, pneumatic and electrical systems."
+        }
+        img={LineClamp1}
+      />
+      <Description
+        text={
+          "Line clamps are available with or without cushion materials; clamps with cushion materials are typically utilized for vibration intense conditions. J&M Products utilize a wide variety of specialized elastomer cushion materials for use in extreme environments, such as exposure to fuel and hydraulic fluids with temperature fluctuations from 500°F. to -20°F."
+        }
+        img={LineClamp2}
+        float={"right"}
+      />
+
+      <Description
+        text={
+          "Reliable, proven, off-the-shelf standard MS, NAS, AN and J&M Part numbers, J&M clamps provide fast economical methods of installing wire harnesses, hydraulic lines, or a variety of other applications. J&M line clamps are utilized by virtually every aircraft manufacturer and defense contractor. Heavy duty trucking, Space and Marine applications are also part of our product line."
+        }
+        img={LineClamp3}
+      />
+
+      <Description
+        text={
+          "J&M can customize any required mounting brackets where vibration or loads would exceed clamp, component design limits, or if compound angles are required. Brackets can include the installation of secondary fastening devices as required."
+        }
+        img={LineClamp4}
+        float={"right"}
+      />
+    </div>
+  );
 };
 
 export default LineClamps;


### PR DESCRIPTION
used description component in lineclamps.jsx

small screens have some issues with the description component: 
![image](https://github.com/acm-ucr/jm-products-website/assets/117532511/a879b255-985a-44e4-ab0a-dedec11d54a6)

medium screen: 
![image](https://github.com/acm-ucr/jm-products-website/assets/117532511/86e0d49d-99bf-4250-98c7-9229d594b095)

large screen: 
![image](https://github.com/acm-ucr/jm-products-website/assets/117532511/d06e668b-0fe3-4b46-8f67-07a3f1d21c0a)

also, edits for a previous pull request I've made are included, but I didn't git add/commit that file. I'm not sure how to resolve this but I believe the edits should be merged in any way through my last pull request.

fixes #22 