### PR TITLE
Line Clamps Link Adjustments

### DIFF
--- a/src/components/clamps/LineClamps.jsx
+++ b/src/components/clamps/LineClamps.jsx
@@ -36,7 +36,7 @@ const LineClamps = () => {
         img={LineClamp4}
         float={"right"}
       />
-      <div className="text-jm-blue-200 underline flex flex-row gap-3">
+      <div className="text-jm-blue-200 underline flex flex-row gap-3 hover:text-jm-blue-300">
         <Link
           href="http://www.jmproducts.com/JMPdocs/JMPcatalogue2001.pdf"
           target="_blank"

--- a/src/components/clamps/LineClamps.jsx
+++ b/src/components/clamps/LineClamps.jsx
@@ -37,7 +37,10 @@ const LineClamps = () => {
         float={"right"}
       />
       <div className="text-jm-blue-200 underline flex flex-row gap-3">
-        <Link href="http://www.jmproducts.com/JMPdocs/JMPcatalogue2001.pdf">
+        <Link
+          href="http://www.jmproducts.com/JMPdocs/JMPcatalogue2001.pdf"
+          target="_blank"
+        >
           View Our Clamp Catalog
         </Link>
         <IoDocumentTextOutline />


### PR DESCRIPTION
hovering upon link changes color from standard to a darker blue. the difference is more noticeable when running:
![image](https://github.com/user-attachments/assets/e050b205-69b6-4953-a15e-bd18a0371c4b)
![image](https://github.com/user-attachments/assets/88ea77d8-a153-4812-95cb-982f51ef310b)

upon clicking the link, it opens a pdf in a new tab as opposed to reloading the current tab.

fixes #39 

