### PR TITLE
Responsify descriptions

### DIFF
--- a/src/components/Description.jsx
+++ b/src/components/Description.jsx
@@ -5,14 +5,16 @@ const Description = ({ text, img, float = "left" }) => {
   return (
     <div className="text-black w-full">
       <div
-        className={`flex justify-center items-center ${
-          float === "right" ? "flex-row-reverse justify-end" : ""
+        className={`flex flex-col sm:flex-row items-center ${
+          float === "right"
+            ? "sm:flex-row-reverse sm:justify-end"
+            : "sm:justify-start"
         }`}
       >
-        <Image src={img} alt="Placeholder" className="w-1/4" />
+        <Image src={img} alt="Placeholder" className="mb-4 sm:w-1/4 w-3/4" />
         <p
-          className={`font-hk text-sm font-normal ${
-            float === "right" ? "mr-12" : "ml-12"
+          className={`font-hk text-xs sm:text-base font-light tracking-wide ${
+            float === "right" ? "sm:mr-12" : "sm:ml-12"
           }`}
         >
           {text}

--- a/src/components/Descriptions.jsx
+++ b/src/components/Descriptions.jsx
@@ -3,7 +3,7 @@ import Description from "./Description";
 
 const Descriptions = ({ data }) => {
   return (
-    <div className="flex items-center flex-col gap-10 w-2/3">
+    <div className="flex items-center flex-col gap-10 w-3/4 sm:w-2/3">
       {data &&
         data.map((item, index) => (
           <Description


### PR DESCRIPTION
line clamps page: 
<img width="556" alt="image" src="https://github.com/user-attachments/assets/05a6231a-f2f1-4981-8edc-a9cd74443b7e">
<img width="870" alt="image" src="https://github.com/user-attachments/assets/76c82e4a-7b17-474f-9c10-fcfb07ad0774">

wire harnesses page: 
<img width="517" alt="image" src="https://github.com/user-attachments/assets/14749100-3ce9-400e-b80d-e043279bd482">
<img width="864" alt="image" src="https://github.com/user-attachments/assets/8cdb4f31-c74d-48c2-bdbd-377ab1c4e278">


fixes #79 