### PR TITLE
PDF Link Responsiveness

### DIFF
--- a/src/components/PDFLink.jsx
+++ b/src/components/PDFLink.jsx
@@ -4,11 +4,11 @@ import { IoDocumentTextOutline } from "react-icons/io5";
 
 const PDFLink = ({ text, link }) => {
   return (
-    <div className="text-jm-blue-200 underline flex flex-row gap-3 hover:text-jm-blue-300">
+    <div className="text-jm-blue-200 underline flex flex-row gap-2 lg:gap-3 hover:text-jm-blue-300 items-center">
       <Link href={link} target="_blank">
         {text}
       </Link>
-      <IoDocumentTextOutline className="flex-shrink-0 " />
+      <IoDocumentTextOutline className="flex-shrink-0" />
     </div>
   );
 };

--- a/src/components/PDFLink.jsx
+++ b/src/components/PDFLink.jsx
@@ -8,7 +8,7 @@ const PDFLink = ({ text, link }) => {
       <Link href={link} target="_blank">
         {text}
       </Link>
-      <IoDocumentTextOutline />
+      <IoDocumentTextOutline className="flex-shrink-0 " />
     </div>
   );
 };


### PR DESCRIPTION
small: 
<img width="320" alt="image" src="https://github.com/user-attachments/assets/d521952e-8ebd-468f-a89f-8eddfeb09bef">

md: 
<img width="256" alt="image" src="https://github.com/user-attachments/assets/3069e7e9-7031-4194-9260-419dde8e7250">

lg+:
<img width="328" alt="image" src="https://github.com/user-attachments/assets/945b3302-21af-49f3-aebe-a9cf16d3f6fe">

* adjusted vertical alignment of pdf icon so it's center aligned with the link
* disabled flex shrink for icons when link is 2+ lines
* made responsive gap sizes between link and icon

fixes #85 